### PR TITLE
graphviz

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is a Haskell combinator library implementing _open games_, a battery of examples, and a code generation tool for making the combinator library practical to work with.
 
-This repo is a refactored and simplified implementation on the basis of [this](https://github.com/jules-hedges/open-game-engine) version by Jules Hedges. 
+This repo is a refactored and simplified implementation on the basis of [this](https://github.com/jules-hedges/open-game-engine) version by Jules Hedges.
 
-If you have questions, drop me (Philipp) a [mail](mailto:philipp.zahn@unisg.ch)!  
+If you have questions, drop me (Philipp) a [mail](mailto:philipp.zahn@unisg.ch)!
 
 # Run the code
 
@@ -15,10 +15,22 @@ targets respectively.
 
 # Usage
 
-There is a [tutorial](https://github.com/philipp-zahn/open-games-hs/blob/master/Tutorial/TUTORIAL.md) how to use the software for modelling. 
+There is a [tutorial](https://github.com/philipp-zahn/open-games-hs/blob/master/Tutorial/TUTORIAL.md) how to use the software for modelling.
 
 
 # Implementation details
 
 tbd
 
+# Using the graph visualiser
+
+If you run `stack run` you will have a `dotfile` appear, this is a graphviz file that can be interpreted with graphviz with the following
+command:
+
+```
+dot -Tsvg dotfile > output.svg
+```
+
+This will create an SVG that you can open with any SVG viewer (like a web browser). The graph is generated from the `parseTree` of a game,
+you will find this in `graphics/Main.hs` where the main function simply prints the dot file from the game passed in argument. If you want
+to use a different game, you can pass it a new parsetree using the `parseTree` quasiquote.

--- a/graphics/Main.hs
+++ b/graphics/Main.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Preprocessor.THSyntax
+import Preprocessor.TH
+import Preprocessor.AbstractSyntax
+import Preprocessor.Compile
+import Graphics as Gfx
+
+import Data.GraphViz
+import Data.GraphViz.Attributes.Complete
+import Data.GraphViz.Commands.IO
+
+
+customParams :: GraphvizParams n String Gfx.ArrowType () String
+customParams = let rec = quickParams :: GraphvizParams n String Gfx.ArrowType () String in
+                   rec { fmtNode = \x -> Shape BoxShape : (fmtNode rec x)
+                       , fmtEdge = \case (_, _, (Contravariant lbl)) -> [Label $ toLabelValue lbl, Style [SItem Dotted []]]
+                                         (_, _, Covariant lbl) -> [Label $ toLabelValue lbl, Style [SItem Solid []]]
+                                         (_, _, Gfx.Both lbl) -> [Label $ toLabelValue lbl, Style [SItem Dotted [], SItem Solid []]] }
+
+bidding = [parseTree|
+
+   inputs    :      ;
+   feedback  :      ;
+
+   :-----------------:
+
+   label : AliceDraw ;
+   inputs    :      ;
+   feedback  :      ;
+   operation : natureDrawsTypeStage "Alice" ;
+   outputs   :  aliceValue ;
+   returns   :      ;
+
+   label : BobDraw ;
+   inputs    :      ;
+   feedback  :      ;
+   operation : natureDrawsTypeStage "Bob" ;
+   outputs   :  bobValue ;
+   returns   :      ;
+
+   label : CarolDraw ;
+   inputs    :      ;
+   feedback  :      ;
+   operation : natureDrawsTypeStage "Carol" ;
+   outputs   :  carolValue ;
+   returns   :      ;
+
+   label : AliceBid ;
+   inputs    :  aliceValue    ;
+   feedback  :      ;
+   operation :  biddingStage "Alice" ;
+   outputs   :  aliceDec ;
+   returns   :  payments  ;
+
+   label : BobBid ;
+   inputs    :  bobValue    ;
+   feedback  :      ;
+   operation :  biddingStage "Bob" ;
+   outputs   :  bobDec ;
+   returns   :  payments  ;
+
+   label : CarolBid ;
+   inputs    :  carolValue    ;
+   feedback  :      ;
+   operation :  biddingStage "Carol" ;
+   outputs   :  carolDec ;
+   returns   :  payments  ;
+
+   label : Auction ;
+   inputs    :  [("Alice",aliceDec),("Bob",bobDec),("Carol",carolDec)]  ;
+   feedback  :      ;
+   operation :   transformPayments kPrice kSlots noLotteries paymentFunction ;
+   outputs   :  payments ;
+   returns   :      ;
+   :-----------------:
+
+   outputs   :      ;
+   returns   :      ;
+   |]
+
+
+
+main :: IO ()
+main = writeDotFile "dotfile" (graphToDot customParams (convertBlock bidding))

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ library:
     - Examples.Markov.RepeatedPD
     - Examples.Markov.RepeatedPDNonState
     - Examples.Markov.TwoStageMarkov
+    - Graphics
 
 dependencies:
     - base >=4.7 && <5
@@ -56,7 +57,10 @@ dependencies:
     - haskeline
     - hashmap
     - hashable
-    - extra 
+    - extra
+    - fgl
+    - graphviz
+    - lens
 
 executables:
   open-games-exe:
@@ -68,6 +72,13 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - open-games-hs
+  graphics:
+    main:                Main.hs
+    source-dirs:         graphics
+    dependencies:
+      - open-games-hs
+      - graphviz
+      - template-haskell
 
 benchmarks:
   learning-bench:

--- a/src/Engine/AtomicGames.hs
+++ b/src/Engine/AtomicGames.hs
@@ -139,6 +139,6 @@ liftStochasticForward process =  [opengame|
 
 generateGame "pureDecision2" ["actionSpace","payoffFunction","playerName"] $
   (Block ["observation"] []
-         [Line [[|observation|]] [] [|dependentDecision playerName (\y -> actionSpace)|] ["action"] [[|payoffFunction observation action returns|]]]
+         [mkLine [[|observation|]] [] [|dependentDecision playerName (\y -> actionSpace)|] ["action"] [[|payoffFunction observation action returns|]]]
          [[|action|]] ["returns"])
 

--- a/src/Graphics.hs
+++ b/src/Graphics.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE LambdaCase #-}
+module Graphics where
+
+import Preprocessor.AbstractSyntax as ABS
+
+import Data.GraphViz as GV
+import Data.Graph.Inductive.PatriciaTree
+import Data.Graph.Inductive.Graph
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Lens
+import Data.Data.Lens
+import Data.List
+import Control.Lens.Combinators
+
+import Data.Maybe
+
+import Debug.Trace
+
+freshLabel :: [String] -> [LNode String]
+freshLabel = freshLabelsStateful 0
+  where
+    freshLabelsStateful :: Int -> [String] -> [LNode String]
+    freshLabelsStateful curr [] = []
+    freshLabelsStateful curr (n : ns) = (curr, n) :  freshLabelsStateful (curr + 1) ns
+
+-- | A Data type to store tell if an edge label is a covariant or contravariant arrow in the graph
+data ArrowType = Contravariant String | Covariant String | Both String
+  deriving (Show, Eq)
+
+-- | ArrowTypes are labellable using the string they wrap
+instance Labellable ArrowType where
+  toLabelValue (Contravariant s) = toLabelValue s
+  toLabelValue (Covariant s) = toLabelValue s
+
+-- | An expression contains the name `Name` if any of the constructor of `Exp` uses it
+containsName :: Name -> Exp -> Bool
+containsName nm exp = trace ("searching for " ++ show nm ++ " in expression " ++ show exp) $ anyOf (template @Exp @Name) (== nm) exp
+
+-- | Swap the two elements of a pair
+swap :: (a, b) -> (b, a)
+swap (a, b) = (b, a)
+
+isOpposite :: ArrowType -> ArrowType -> Bool
+isOpposite (Covariant _) (Contravariant _) = True
+isOpposite (Contravariant _) (Covariant _) = True
+isOpposite _ _ = False
+
+getName :: ArrowType -> String
+getName (Covariant nm) = nm
+getName (Contravariant nm) = nm
+getName (Graphics.Both nm) = nm
+
+remove :: Int -> [a] ->  [a]
+remove 0 (x : xs) = xs
+remove n (y : ys) = y : remove (n - 1) ys
+
+convertBoth :: (a -> a -> Bool) -> (a -> a) -> [a] -> [a]
+convertBoth test map [] = []
+convertBoth test map (a : as) = case ifind (const $ test a) as of
+                                     Just (idx, val) -> map val : convertBoth test map (remove idx as)
+                                     Nothing -> a : convertBoth test map as
+
+-- | Return all the edges from one `Line`
+getEdgesFromName :: Name  -- ^ The name of the line
+                 -> Int -- ^ The id of the line
+                 -> [Line (String, Int) Pat Exp]  -- ^ The list of all the other lines
+                 -> [LEdge ArrowType] -- ^ The list of edges from the line with given name and id to all the other lines
+getEdgesFromName name id lines = [ (id, snd (label ln), Contravariant (show name))
+                                 | ln <- lines
+                                 , any (containsName name) ((contravariantInputs ln ))
+                                 ] ++ [ (id, snd (label ln), Covariant (show name))
+                                 | ln <- lines
+                                 , any (containsName name) ((covariantInputs ln))
+                                 ]
+
+-- | Get the edges for all lines by looking at each covariant and contravariant outputs and mapping it to the list
+-- of lines which references them.
+getEdges :: [Line (String, Int) Pat Exp] -> Line (String, Int) Pat Exp -> [LEdge ArrowType]
+getEdges allLines line = let outputs = traverse getName (covariantOutputs line ++ contravariantOutputs line)
+                             labels = concat [getEdgesFromName x (snd . label $ line) allLines | x <- fromMaybe [] outputs]
+                          in labels
+  where
+    getName :: Pat -> Maybe Name
+    getName (VarP n) = Just n
+    getName _ = Nothing
+
+-- | Convert a line with optional labels to lines with a label and an id
+-- if the line has no label the label will be `line_id_n` where `n` is the id of the line
+convertLines :: [Line (Maybe String) Pat Exp] -> [Line (String, Int) Pat Exp]
+convertLines ln = convertLinesRec 0 ln
+  where
+  convertLinesRec :: Int -> [Line (Maybe String) Pat Exp] -> [Line (String, Int) Pat Exp]
+  convertLinesRec n [] = []
+  convertLinesRec n (Line nm a b c d e : ls) = Line (fromMaybe ("line_id_" ++ show n) nm, n) a b c d e : convertLinesRec (n + 1) ls
+
+-- | Build a graph using lines as nodes and argument dependency for nodes
+toGraph :: [Line (String, Int) Pat Exp] -> Gr String ArrowType
+toGraph ln =
+    let edges = concat $ map (getEdges ln) ln in
+        mkGraph (map (swap . label) ln) (trace ("edges are " ++ show edges) edges)
+
+-- | Given a block, convert it into a graph using all lines as nodes and dependencies between them as arrows
+convertBlock :: Block Pat Exp -> Gr String ArrowType
+convertBlock = toGraph . convertLines . blockLines
+

--- a/src/Preprocessor/AbstractSyntax.hs
+++ b/src/Preprocessor/AbstractSyntax.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Preprocessor.AbstractSyntax
   ( Line(..)
   , pureLine
+  , mkLine
   , Block(..)
   ) where
 
@@ -31,42 +33,47 @@ import Data.Bifunctor
 -- I decided to keep the record field names verbose, and I expect the user to specify lines in constructor syntax
 -- rather than record syntax
 
-data Line p e = Line {
+data Line l p e = Line {
+  label :: l,
   covariantInputs :: [e], contravariantOutputs :: [p],
   matrix :: e, --
   covariantOutputs :: [p], contravariantInputs :: [e]} deriving (Eq, Show, Functor)
 
-instance Comonad (Line p) where
-  extract (Line _ _ e _ _) = e
+mkLine :: [e] -> [p] -> e -> [p] -> [e] -> Line (Maybe l) p e
+mkLine = Line Nothing
+
+
+instance Comonad (Line (Maybe l) p) where
+  extract (Line _ _ _ e _ _) = e
   extend f v = pure (f v)
 
-instance Bifunctor Line where
-  first f (Line covi cono m covo coni) =
-    Line covi (fmap f cono) m (fmap f covo) coni
+instance Bifunctor (Line l) where
+  first f (Line lbl covi cono m covo coni) =
+    Line lbl covi (fmap f cono) m (fmap f covo) coni
   second = fmap
 
-pureLine :: forall p a. a -> Line p a
-pureLine v = Line [] [] v [] []
+pureLine :: forall l p a. a -> Line (Maybe l) p a
+pureLine v = Line Nothing [] [] v [] []
 
-instance Applicative (Line p) where
+instance Applicative (Line (Maybe l) p) where
   pure = pureLine
-  (Line _ _ f _ _) <*> (Line covIn conOut m covOut conIn) =
-    Line (fmap f covIn) conOut (f m) covOut (fmap f conIn)
+  (Line _ _ _ f _ _) <*> (Line label covIn conOut m covOut conIn) =
+    Line label (fmap f covIn) conOut (f m) covOut (fmap f conIn)
 
-instance Foldable (Line p) where
-  foldr f init (Line _ _ arg _ _)  = f arg init
+instance Foldable (Line l p) where
+  foldr f init (Line _ _ _ arg _ _)  = f arg init
 
-instance Traversable (Line p) where
-  traverse f (Line covIn conOut m covOut conIn) =
-    pure Line <*> traverse f covIn
-              <*> pure conOut
-              <*> f m
-              <*> pure covOut
-              <*> traverse f conIn
+instance Traversable (Line l p) where
+  traverse f (Line lbl covIn conOut m covOut conIn) =
+    pure (Line lbl) <*> traverse f covIn
+                    <*> pure conOut
+                    <*> f m
+                    <*> pure covOut
+                    <*> traverse f conIn
 
 data Block p e = Block {
   blockCovariantInputs :: [p], blockContravariantOutputs :: [e],
-  blockLines :: [Line p e],
+  blockLines :: [Line (Maybe String) p e],
   blockCovariantOutputs :: [e], blockContravariantInputs :: [p]} deriving (Eq, Show, Functor)
 
 
@@ -81,7 +88,7 @@ instance Applicative (Block p) where
           (mapLines f covOut)
           conIn
       where
-        mapLines :: [Line p (a -> b)] -> [a] -> [b]
+        mapLines :: [Line (Maybe String) p (a -> b)] -> [a] -> [b]
         mapLines f as = fmap extract f <*> as
 
 

--- a/src/Preprocessor/Lambda.hs
+++ b/src/Preprocessor/Lambda.hs
@@ -7,8 +7,6 @@ module Preprocessor.Lambda
   , Literal(..)
   , LRange(..)
   , Pattern(..)
-  , ParsedBlock(..)
-  , ParsedLine(..)
   , expr
   , parseLine
   , parseBlock
@@ -28,6 +26,7 @@ import qualified Text.Parsec.Expr     as Ex
 import qualified Text.Parsec.Token    as Tok
 import Text.Parsec.Language
 import Text.ParserCombinators.Parsec.Expr
+import Preprocessor.AbstractSyntax as ABS
 
 type Name = String
 
@@ -273,54 +272,48 @@ appl = do
 expr :: Parser Lambda
 expr =  infixParser appl
 
-data ParsedLine p e = MkParsedLine { covOut :: [p]
-                                   , conIn :: [e]
-                                   , op :: e
-                                   , conOut :: [p]
-                                   , covIn :: [e]
-                                   } deriving (Eq, Show)
+parseLine :: Parser p -> Parser e -> Parser (ABS.Line (Maybe String) p e)
+parseLine parseP parseE = do
+    covo <- (commaSep parseP <* reservedOp "|")
+    coni <- (commaSep parseE  <* reservedOp "<-")
+    matrix <- (parseE <* reservedOp "-<")
+    cono <- (commaSep parseP <* reservedOp "|")
+    covi <- (commaSep parseE <* reservedOp ";")
+    pure (Line Nothing covi cono matrix covo coni)
 
-data ParsedBlock p e l = MkParsedBlock [p] [e] [l] [p] [e]
-
-parseLine :: Parser p -> Parser e -> Parser (ParsedLine p e)
-parseLine parseP parseE = pure MkParsedLine
-    <*> (commaSep parseP <* reservedOp "|")
-    <*> (commaSep parseE  <* reservedOp "<-")
-    <*> (parseE <* reservedOp "-<")
-    <*> (commaSep parseP <* reservedOp "|")
-    <*> (commaSep parseE <* reservedOp ";")
-
-parseBlock :: Parser p -> Parser e -> Parser l -> Parser (ParsedBlock p e l)
-parseBlock parseP parseE lineParser =
-  pure MkParsedBlock  <*> (commaSep parseP <* reservedOp "||")
-                      <*> (commaSep parseE <* reservedOp "=>>")
-                      <*> (many lineParser <* reservedOp "<<=")
-                      <*> (commaSep parseP <* reservedOp "||")
-                      <*> (commaSep parseE)
+parseBlock :: Parser p -> Parser e -> Parser (Block p e)
+parseBlock parseP parseE = do
+    covi <- (commaSep parseP <* reservedOp "||")
+    cono <- (commaSep parseE <* reservedOp "=>>")
+    lines <- (many (parseLine parseP parseE) <* reservedOp "<<=")
+    coni <- (commaSep parseP <* reservedOp "||")
+    covo <- (commaSep parseE)
+    pure (Block covi cono lines covo coni)
 
 parseTwoLines :: String -> String -> Parser p -> Parser e -> Parser ([p], [e])
 parseTwoLines kw1 kw2 parseP parseE =
     pair (reserved kw1 *> colon *> commaSep parseP <* semi )
          (option [] (reserved kw2 *> colon *> commaSep parseE <* semi ))
- <|> (([], ) <$> (reserved kw2 *> colon *> commaSep parseE <* semi))
+     <|> (([], ) <$> (reserved kw2 *> colon *> commaSep parseE <* semi))
 
 parseInput = parseTwoLines "inputs" "feedback"
 
-parseOutput = parseTwoLines "outputs" "returns" 
+parseOutput = parseTwoLines "outputs" "returns"
 
 parseDelimiter = colon *> many1 (string "-") <* colon
 
-parseVerboseLine :: Parser p -> Parser e -> Parser (ParsedLine p e)
+parseVerboseLine :: Parser p -> Parser e -> Parser (ABS.Line (Maybe String) p e)
 parseVerboseLine parseP parseE = do
+  lbl <- optionMaybe (reserved "label" *> colon *> manyTill anyChar semi)
   (input, feedback) <- option ([], []) (parseInput parseE parseP)
   program <- reserved "operation" *> colon *> parseE <* semi
   (outputs,returns) <- option ([], []) (parseOutput parseP parseE)
-  pure $ MkParsedLine outputs returns program feedback input
+  pure $ ABS.Line lbl input feedback program outputs returns
 
-
-parseVerboseSyntax :: Parser p -> Parser e -> Parser l -> Parser (ParsedBlock p e l)
-parseVerboseSyntax parseP parseE parseL =
+parseVerboseSyntax :: Parser p -> Parser e -> Parser (Block p e)
+parseVerboseSyntax parseP parseE =
   do (input, feedback) <- try (parseInput parseP parseE <* parseDelimiter) <|> pure ([], [])
-     lines <- many parseL
+     lines <- many (parseVerboseLine parseP parseE)
      (outputs,returns) <- option ([], []) (parseDelimiter *> parseOutput parseE parseP)
-     return $ MkParsedBlock input feedback lines returns outputs
+     eof
+     return $ Block input feedback lines outputs returns

--- a/src/Preprocessor/Parser.hs
+++ b/src/Preprocessor/Parser.hs
@@ -3,9 +3,9 @@ module Preprocessor.Parser where
 
 import Text.Parsec
 import Text.Parsec.String
+import Language.Haskell.TH
 import Preprocessor.Lambda
-
-type GameAST p e = ParsedBlock p e (ParsedLine p e)
+import Preprocessor.AbstractSyntax
 
 word :: Parser String
 word = many1 alphaNum
@@ -16,14 +16,16 @@ quoted = char '"' *> manyTill anyChar (char '"')
 uncurry5 :: (a -> b -> c -> d -> e -> f) -> (a, b, c, d, e) -> f
 uncurry5 f (x, y, z, w, v) = f x y z w v
 
-lineSep :: String-> Parser ()
+lineSep :: String -> Parser ()
 lineSep str = spaces <* string str <* spaces
 
-realParser :: Parser (GameAST Pattern Lambda)
-realParser =  parseBlock parsePattern expr (parseLine parsePattern expr) <* eof
+realParser :: Parser (Block Pattern Lambda)
+realParser =  parseBlock parsePattern expr <* eof
 
-parseLambda :: String -> Either ParseError (GameAST Pattern Lambda)
+parseLambda :: String -> Either ParseError (Block Pattern Lambda)
 parseLambda = parse realParser "realParser"
 
-parseVerbose :: String -> Either ParseError (GameAST Pattern Lambda)
-parseVerbose = parse (parseVerboseSyntax parsePattern expr (parseVerboseLine parsePattern expr)) "verbose parser"
+parseVerbose :: String -> Either ParseError (Block Pattern Lambda)
+parseVerbose = parse (parseVerboseSyntax parsePattern expr) "verbose parser"
+
+

--- a/src/Preprocessor/Preprocessor.hs
+++ b/src/Preprocessor/Preprocessor.hs
@@ -8,8 +8,6 @@ module Preprocessor.Preprocessor
   , compilePattern
   , compLine
   , convertGame
-  , compileGameLine
-  , compileAST
   , parseLambdaAsOpenGame
   , parseLambdaAsExp
   , game

--- a/src/Preprocessor/THSyntax.hs
+++ b/src/Preprocessor/THSyntax.hs
@@ -19,17 +19,17 @@ import Data.List (inits, tails)
 import Data.Bifunctor
 
 
-type SLine = Line Pat Exp
-type QLine = Line String (Q Exp)
+type SLine = Line (Maybe String) Pat Exp
+type QLine = Line (Maybe String) String (Q Exp)
 type GBlock = Block SLine
 
 data LineWithContext p e = LineWithContext {
-  line :: Line p e,
+  line :: Line (Maybe String) p e,
   covariantContext :: Variables p,
   contravariantContext :: Variables p}
 
 class ToLine pat exp where
-  toLine :: Line pat exp -> Q SLine
+  toLine :: Line (Maybe String) pat exp -> Q SLine
 
 instance ToLine Pat Exp where
   toLine = pure
@@ -84,7 +84,7 @@ compileQLine qline = do covIn <- traverse id $ covariantInputs qline
                         exp <- matrix qline
                         let covOut = fmap (VarP . mkName) (covariantOutputs qline)
                         let conOut = fmap (VarP . mkName) (contravariantOutputs qline)
-                        pure $ Line covIn conOut exp covOut conIn
+                        pure $ mkLine covIn conOut exp covOut conIn
 
 class GameCompiler term where
   generateGame :: String -> [String] -> term -> Q [Dec]


### PR DESCRIPTION
Port the changes to the AST from the original repository. There
are no differences between Block/Lines from the parser and Block/Lines
fed to the open games engine. Additionally this makes `parseTree`
available as a quasiquote to inspect, print and analyse open games.