### PR TITLE
Add glog/RIO to MonadOptic/MonadContext, IOGames & Continuation

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -64,6 +64,9 @@ dependencies:
     - vector
     - monad-bayes
     - criterion
+    - rio
+    - directory
+    - bytestring
 
 executables:
   open-games-exe:

--- a/src/Engine/Diagnostics.hs
+++ b/src/Engine/Diagnostics.hs
@@ -109,3 +109,94 @@ generateIsEq :: forall xs.
                ) => List xs -> IO ()
 generateIsEq hlist = putStrLn $
   "----Analytics begin----" ++ (foldrL Concat "" $ mapL @_ @_ @(ConstMap String xs) PrintIsEq hlist) ++ "----Analytics end----\n"
+
+
+--------------------------------------------------------
+-- Diagnosticinformation and processesing of information
+-- for standard simple Monte Carlo
+{--
+-- Defining the necessary types for outputting information of a BayesianGame
+data DiagnosticsMC x y = DiagnosticsMC {
+  playerNameMC :: String
+  , averageUtilStrategyMC :: Double
+  , samplePayoffsMC :: [Double]
+  , currentMoveMC :: x
+  , optimalMoveMC :: y
+  , optimalPayoffMC :: Double
+  }
+  deriving (Show)
+
+
+-- prepare string information for Bayesian game
+showDiagnosticInfo :: (Show y, Ord y, Show x) => DiagnosticInfoBayesian x y -> String
+showDiagnosticInfo info =
+     "\n"    ++ "Player: " ++ player info
+     ++ "\n" ++ "Optimal Move: " ++ (show $ optimalMove info)
+     ++ "\n" ++ "Current Strategy: " ++ (show $ strategy info)
+     ++ "\n" ++ "Optimal Payoff: " ++ (show $ optimalPayoff info)
+     ++ "\n" ++ "Current Payoff: " ++ (show $ payoff info)
+     ++ "\n" ++ "Observable State: " ++ (show $ state info)
+     ++ "\n" ++ "Unobservable State: " ++ (show $ unobservedState info)
+
+
+
+-- output string information for a subgame expressions containing information from several players - bayesian
+showDiagnosticInfoL :: (Show y, Ord y, Show x) => [DiagnosticInfoBayesian x y] -> String
+showDiagnosticInfoL [] = "\n --No more information--"
+showDiagnosticInfoL (x:xs)  = showDiagnosticInfo x ++ "\n --other game-- " ++ showDiagnosticInfoL xs
+
+-- checks equilibrium and if not outputs relevant deviations
+checkEqL :: (Show y, Ord y, Show x) => [DiagnosticInfoBayesian x y] -> String
+checkEqL ls = let xs = fmap equilibrium ls
+                  ys = filter (\x -> equilibrium x == False) ls
+                  isEq = and xs
+                  in if isEq == True then "\n Strategies are in equilibrium"
+                                      else "\n Strategies are NOT in equilibrium. Consider the following profitable deviations: \n"  ++ showDiagnosticInfoL ys
+
+----------------------------------------------------------
+-- providing the relevant functionality at the type level
+-- for show output
+
+data ShowDiagnosticOutput = ShowDiagnosticOutput
+
+instance (Show y, Ord y, Show x) => Apply ShowDiagnosticOutput [DiagnosticInfoBayesian x y] String where
+  apply _ x = showDiagnosticInfoL x
+
+
+data PrintIsEq = PrintIsEq
+
+instance (Show y, Ord y, Show x) => Apply PrintIsEq [DiagnosticInfoBayesian x y] String where
+  apply _ x = checkEqL x
+
+
+data PrintOutput = PrintOutput
+
+instance (Show y, Ord y, Show x) => Apply PrintOutput [DiagnosticInfoBayesian x y] String where
+  apply _ x = showDiagnosticInfoL x
+
+
+data Concat = Concat
+
+instance Apply Concat String (String -> String) where
+  apply _ x = \y -> x ++ "\n NEWGAME: \n" ++ y
+
+
+---------------------
+-- main functionality
+
+-- all information for all players
+generateOutput :: forall xs.
+               ( MapL   PrintOutput xs     (ConstMap String xs)
+               , FoldrL Concat String (ConstMap String xs)
+               ) => List xs -> IO ()
+generateOutput hlist = putStrLn $
+  "----Analytics begin----" ++ (foldrL Concat "" $ mapL @_ @_ @(ConstMap String xs) PrintOutput hlist) ++ "----Analytics end----\n"
+
+-- output equilibrium relevant information
+generateIsEq :: forall xs.
+               ( MapL   PrintIsEq xs     (ConstMap String xs)
+               , FoldrL Concat String (ConstMap String xs)
+               ) => List xs -> IO ()
+generateIsEq hlist = putStrLn $
+  "----Analytics begin----" ++ (foldrL Concat "" $ mapL @_ @_ @(ConstMap String xs) PrintIsEq hlist) ++ "----Analytics end----\n"
+-}

--- a/src/Engine/Diagnostics.hs
+++ b/src/Engine/Diagnostics.hs
@@ -22,7 +22,7 @@ import Engine.TLL
 
 --------------------------------------------------------
 -- Diagnosticinformation and processesing of information
--- for standard game-theoretic analysis
+-- for standard Bayesian game-theoretic analysis
 
 -- Defining the necessary types for outputting information of a BayesianGame
 data DiagnosticInfoBayesian x y = DiagnosticInfoBayesian
@@ -39,7 +39,7 @@ data DiagnosticInfoBayesian x y = DiagnosticInfoBayesian
 
 -- prepare string information for Bayesian game
 showDiagnosticInfo :: (Show y, Ord y, Show x) => DiagnosticInfoBayesian x y -> String
-showDiagnosticInfo info =  
+showDiagnosticInfo info =
      "\n"    ++ "Player: " ++ player info
      ++ "\n" ++ "Optimal Move: " ++ (show $ optimalMove info)
      ++ "\n" ++ "Current Strategy: " ++ (show $ strategy info)
@@ -50,10 +50,10 @@ showDiagnosticInfo info =
 
 
 
--- output string information for a subgame expressions containing information from several players - bayesian 
+-- output string information for a subgame expressions containing information from several players - bayesian
 showDiagnosticInfoL :: (Show y, Ord y, Show x) => [DiagnosticInfoBayesian x y] -> String
 showDiagnosticInfoL [] = "\n --No more information--"
-showDiagnosticInfoL (x:xs)  = showDiagnosticInfo x ++ "\n --other game-- " ++ showDiagnosticInfoL xs 
+showDiagnosticInfoL (x:xs)  = showDiagnosticInfo x ++ "\n --other game-- " ++ showDiagnosticInfoL xs
 
 -- checks equilibrium and if not outputs relevant deviations
 checkEqL :: (Show y, Ord y, Show x) => [DiagnosticInfoBayesian x y] -> String
@@ -109,4 +109,3 @@ generateIsEq :: forall xs.
                ) => List xs -> IO ()
 generateIsEq hlist = putStrLn $
   "----Analytics begin----" ++ (foldrL Concat "" $ mapL @_ @_ @(ConstMap String xs) PrintIsEq hlist) ++ "----Analytics end----\n"
-

--- a/src/Examples/Markov/TestSimpleMonteCarlo.hs
+++ b/src/Examples/Markov/TestSimpleMonteCarlo.hs
@@ -8,12 +8,15 @@
 module Examples.Markov.TestSimpleMonteCarlo where
 
 import           Engine.Engine
-import           Preprocessor.Preprocessor
-import           Examples.SimultaneousMoves (ActionPD(..),prisonersDilemmaMatrix)
+import           Engine.IOGames (logFuncSilent)
 import           Examples.Markov.TestSimpleMonteCarlo.Continuation
+import           Examples.SimultaneousMoves (ActionPD(..),prisonersDilemmaMatrix)
+import           Preprocessor.Preprocessor
+import qualified RIO
+import           RIO (RIO, glog, GLogFunc, HasGLogFunc(..))
 
-import           Control.Monad.State  hiding (state,void)
-import qualified Control.Monad.State  as ST
+import           Control.Monad.State hiding (state,void)
+import qualified Control.Monad.State as ST
 import qualified Data.Vector as V
 import           Debug.Trace
 import           System.Random.MWC.CondensedTable
@@ -89,7 +92,7 @@ strategyTupleTest = stageStrategyTest ::- stageStrategyTest ::- Nil
 
 
 -- fix context used for the evaluation
-contextCont sampleSize iterator strat initialAction = StochasticStatefulContext (pure ((),initialAction)) (\_ action -> trace "cont" (sampleDetermineContinuationPayoffsStoch sampleSize iterator strat action))
+contextCont sampleSize iterator strat initialAction = StochasticStatefulContext (pure ((),initialAction)) (\_ action -> trace "cont" (sampleDetermineContinuationPayoffsStoch (RIO.mkGLogFunc logFuncSilent) sampleSize iterator strat action))
 
 
 

--- a/src/Examples/Markov/TestSimpleMonteCarlo.hs
+++ b/src/Examples/Markov/TestSimpleMonteCarlo.hs
@@ -92,11 +92,11 @@ strategyTupleTest = stageStrategyTest ::- stageStrategyTest ::- Nil
 
 
 -- fix context used for the evaluation
-contextCont sampleSize iterator strat initialAction = StochasticStatefulContext (pure ((),initialAction)) (\_ action -> trace "cont" (sampleDetermineContinuationPayoffsStoch (RIO.mkGLogFunc logFuncSilent) sampleSize iterator strat action))
+contextCont sample1 sample2 sampleSize iterator strat initialAction = StochasticStatefulContext (pure ((),initialAction)) (\_ action -> sampleDetermineContinuationPayoffsStoch (RIO.mkGLogFunc logFuncSilent) sample1 sample2 sampleSize iterator strat action)
 
 
 
-repeatedPDEq sampleSize iterator strat initialAction = evaluate prisonersDilemma strat context
-  where context  = contextCont sampleSize iterator strat initialAction
+repeatedPDEq sample1 sample2 sampleSize iterator strat initialAction = evaluate prisonersDilemma strat context
+  where context  = contextCont sample1 sample2 sampleSize iterator strat initialAction
 
-eqOutput sampleSize iterator strat initialAction = generateIsEq $ repeatedPDEq sampleSize iterator strat initialAction
+eqOutput sample1 sample2 sampleSize iterator strat initialAction = generateIsEq $ repeatedPDEq sample1 sample2 sampleSize iterator strat initialAction

--- a/src/Examples/Markov/TestSimpleMonteCarlo/Continuation.hs
+++ b/src/Examples/Markov/TestSimpleMonteCarlo/Continuation.hs
@@ -80,7 +80,7 @@ prisonersDilemmaCont :: OpenGame
                           (MonadContext (Msg ActionPD))
                           ('[Kleisli CondensedTableV (ActionPD, ActionPD) ActionPD,
                              Kleisli CondensedTableV (ActionPD, ActionPD) ActionPD])
-                          ('[RIO (GLogFunc (Msg ActionPD)) (Diagnostics (ActionPD, ActionPD) ActionPD), RIO (GLogFunc (Msg ActionPD)) (Diagnostics (ActionPD, ActionPD) ActionPD)])
+                          ('[RIO (GLogFunc (Msg ActionPD)) (DiagnosticsMC (ActionPD, ActionPD) ActionPD), RIO (GLogFunc (Msg ActionPD)) (DiagnosticsMC (ActionPD, ActionPD) ActionPD)])
                           (ActionPD, ActionPD)
                           ()
                           (ActionPD, ActionPD)

--- a/src/Examples/Markov/TestSimpleMonteCarlo/Continuation.hs
+++ b/src/Examples/Markov/TestSimpleMonteCarlo/Continuation.hs
@@ -89,7 +89,7 @@ prisonersDilemmaCont :: SampleSize
                           (MonadContext (Msg ActionPD))
                           ('[Kleisli CondensedTableV (ActionPD, ActionPD) ActionPD,
                              Kleisli CondensedTableV (ActionPD, ActionPD) ActionPD])
-                          ('[RIO (GLogFunc (Msg ActionPD)) (DiagnosticsMC (ActionPD, ActionPD) ActionPD), RIO (GLogFunc (Msg ActionPD)) (DiagnosticsMC (ActionPD, ActionPD) ActionPD)])
+                          ('[RIO (GLogFunc (Msg ActionPD)) (DiagnosticsMC ActionPD), RIO (GLogFunc (Msg ActionPD)) (DiagnosticsMC ActionPD)])
                           (ActionPD, ActionPD)
                           ()
                           (ActionPD, ActionPD)


### PR DESCRIPTION
This PR adds:

1. A log ability to the MonadOptic/MonadContext. 
2. The IOGames now logs things, and provides types of loggers (silent, trace, structured).
3. The Continuation uses `traverseList_` and this new loggable IOGame.
