### PR TITLE
Bug fix: add x to payoffFuncion arguments

### DIFF
--- a/src/Examples/Decision.hs
+++ b/src/Examples/Decision.hs
@@ -121,7 +121,7 @@ singleDecisionPriorReduced actionSpace payoffFunction = [opengame|
    inputs    : x    ;
    operation : dependentDecision "player1" (\x -> actionSpace);
    outputs   : decisionPlayer1 ;
-   returns   : payoffFunction decisionPlayer1     ;
+   returns   : payoffFunction decisionPlayer1  x  ;
   |]
 
 -----------------------------------


### PR DESCRIPTION
# Description of problem

The payoff function used by the `singleDecisionPriorVerbose` game explicitly depends on `x`. When the game is written in reduced form (`singleDecisionPriorReduced`), `x` is omitted. This causes type errors at compile time when the reduced form game is used. 

# Testing
Currently nothing goes wrong as the reduced form game is never used. However, when I replace `singleDecisionPriorVerbose` by `singleDecisionPriorReduced` on line 168 (in the final game `singleDecStoch`), then the file raises the following error during compilation:

```
[30 of 37] Compiling Examples.Markov.NStageMarkov (open-games-hs/src/Examples/Markov/NStageMarkov.hs, interpreted )

open-games-hs/src/Examples/Markov/NStageMarkov.hs:46:1: warning: [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In an equation for ‘transitionEndStateDetermN’:
        Patterns not matched: p _ _ where p is not one of {2, 1, 0, 3}
   |
46 | transitionEndStateDetermN 3  _         _         = playDeterministically 3
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
[31 of 37] Compiling Examples.Decision ( open-games-hs/src/Examples/Decision.hs, interpreted )

open-games-hs/src/Examples/Decision.hs:189:79: error:
    • Couldn't match type ‘Payoff -> Payoff’ with ‘Double’
      Expected type: Payoff -> Payoff
        Actual type: Payoff -> Payoff -> Payoff
    • Probable cause: ‘payoffFunction’ is applied to too few arguments
      In the third argument of ‘singleDecStoch’, namely ‘payoffFunction’
      In the expression:
        singleDecStoch distributionUniformPeak actionSpace payoffFunction
      In an equation for ‘gameSingleDecisionStoch’:
          gameSingleDecisionStoch
            = singleDecStoch distributionUniformPeak actionSpace payoffFunction
    |
189 | gameSingleDecisionStoch  = singleDecStoch distributionUniformPeak actionSpace payoffFunction
    |                                                                               ^^^^^^^^^^^^^^
Failed, 30 modules loaded.

<no location info>: error:
    Could not load module ‘Examples.Auctions.AuctionSupportFunctions’
    It is a member of the hidden package ‘open-games-hs-0.1.0.0’.
    You can run ‘:set -package open-games-hs’ to expose it.
    (Note: this unloads all the modules in the current scope.)

```

# Fix
Add `x` as an argument in the reduced game. Compilation then works fine with the reduced game, and the correct equilibria are returned:

```
> λ: isOptimalSingleDecisionStoch peak
----Analytics begin----
 Strategies are in equilibrium
 NEWGAME:
----Analytics end----
```




