### PR TITLE
`monad-parallel` `sequence` for Monte Carlo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "Opt-in Stack Flake";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        hPkgs =
+          pkgs.haskell.packages."ghc925"; # need to match Stackage LTS version from stack.yaml resolver
+
+        myDevTools = [
+          hPkgs.ghc # GHC compiler in the desired version (will be available on PATH)
+          stack-wrapped
+          pkgs.zlib # External C library needed by some Haskell packages
+        ];
+
+        stack-wrapped = pkgs.symlinkJoin {
+          name = "stack"; # will be available as the usual `stack` in terminal
+          paths = [ pkgs.stack ];
+          buildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/stack \
+              --add-flags "\
+                --no-nix \
+                --system-ghc \
+                --no-install-ghc \
+              "
+          '';
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = myDevTools;
+
+          # Make external Nix c libraries like zlib known to GHC, like
+          # pkgs.haskell.lib.buildStackProject does
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath myDevTools;
+
+          shellHook = ''
+            if test -f "REPO_UNINITIALIZED.sh"; then
+              chmod +x REPO_UNINITIALIZED.sh
+              ./REPO_UNINITIALIZED.sh
+              rm REPO_UNINITIALIZED.sh
+            fi
+          '';
+        };
+      });
+}

--- a/open-games-hs.cabal
+++ b/open-games-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -55,6 +55,7 @@ library
     , haskeline
     , lens
     , monad-bayes
+    , monad-parallel
     , mtl
     , mwc-random
     , parsec
@@ -89,6 +90,7 @@ executable open-games-exe
     , haskeline
     , lens
     , monad-bayes
+    , monad-parallel
     , mtl
     , mwc-random
     , open-games-hs

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ dependencies:
     - random
     - vector
     - criterion
+    - monad-parallel
 
 
 

--- a/src/OpenGames/Engine/BayesianMC.hs
+++ b/src/OpenGames/Engine/BayesianMC.hs
@@ -13,6 +13,8 @@ import Control.Arrow
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.State hiding (state)
 
+import qualified Control.Monad.Parallel as MP
+
 import Control.Monad.Bayes.Class
 import Control.Monad.Bayes.Population
 import Control.Monad.Bayes.Sampler.Strict
@@ -130,8 +132,8 @@ decisionMC numParticles epsilon name options = OpenGame {
                  return $ r + HM.findWithDefault 0.0 name v
                }
      in do { xs <- mcSupport numParticles (fmap snd h);
-             sequence [ do { strategyExpectation <- mcExpectation numParticles (runKleisli a x >>= runInState x);
-                             moveExpectations <- sequence [ do { e <- mcExpectation numParticles (runInState x y);
+             MP.sequence [ do { strategyExpectation <- mcExpectation numParticles (runKleisli a x >>= runInState x);
+                             moveExpectations <- MP.sequence [ do { e <- mcExpectation numParticles (runInState x y);
                                                                  return (y, e)
                                                                }
                                                           | y <- options x ];


### PR DESCRIPTION
Just changing the external sequence operation in `decisionMC` to its parallel version achieves a noticeable speedup on several machines we tested it on (for the simple test case we have right now).